### PR TITLE
Update singer-python version

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -11,7 +11,7 @@ setup(name='target-csv',
       py_modules=['target_csv'],
       install_requires=[
           'jsonschema==2.6.0',
-          'singer-python==0.1.0',
+          'singer-python==2.1.0',
       ],
       entry_points='''
           [console_scripts]


### PR DESCRIPTION
Hi, guys,

when I installed the target-csv it broke my tap-adwords because it uninstalled the up to date version of singer-python to install the older one. I reinstalled the up to date version and both the tap-adwords and target-csv worked fine. So I think it is better to update here for everyone.

Thank you for Open Sourcing these nice projects,

João Marcos