### PR TITLE
No pinning down of dependency to specific version

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -10,8 +10,8 @@ setup(name='target-csv',
       classifiers=['Programming Language :: Python :: 3 :: Only'],
       py_modules=['target_csv'],
       install_requires=[
-          'jsonschema==2.6.0',
-          'singer-python==2.1.4',
+          'jsonschema>=2.6.0',
+          'singer-python>=2.1.4',
       ],
       entry_points='''
           [console_scripts]


### PR DESCRIPTION
Cleary says that it is wrong
https://packaging.python.org/discussions/install-requires-vs-requirements/