### PR TITLE
Flattening fields with lists should handle complex types

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,0 +1,21 @@
+version: 2.1
+
+orbs:
+  python: circleci/python@0.2.1
+
+jobs:
+  build-and-test:
+    executor: python/default
+    steps:
+      - checkout
+      - python/load-cache
+      - python/install-deps
+      - python/save-cache
+      - run:
+          command: ./manage.py test
+          name: Test
+
+workflows:
+  main:
+    jobs:
+      - build-and-test

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -10,4 +10,4 @@ jobs:
           name: Run tests
           command: |
             pip install -e '.[dev]'
-            nose -v
+            nosetests -v

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,21 +1,13 @@
-version: 2.1
-
-orbs:
-  python: circleci/python@0.2.1
-
+version: 2
 jobs:
-  build-and-test:
-    executor: python/default
+  build:
+    working_directory: ~/project
+    docker:
+      - image: circleci/python:3.7
     steps:
       - checkout
-      - python/load-cache
-      - python/install-deps
-      - python/save-cache
       - run:
-          command: ./manage.py test
-          name: Test
-
-workflows:
-  main:
-    jobs:
-      - build-and-test
+          name: Run tests
+          command: |
+            pip install -e '.[dev]'
+            nose -v

--- a/setup.py
+++ b/setup.py
@@ -13,6 +13,9 @@ setup(name='target-csv',
           'jsonschema==2.6.0',
           'singer-python==2.1.4',
       ],
+      extras_require={
+            'dev': ['nose']
+      },
       entry_points='''
           [console_scripts]
           target-csv=target_csv:main

--- a/target_csv.py
+++ b/target_csv.py
@@ -32,7 +32,7 @@ def flatten(d, parent_key='', sep='__'):
         if isinstance(v, collections.MutableMapping):
             items.extend(flatten(v, new_key, sep=sep).items())
         else:
-            items.append((new_key, json.dumps(v) if type(v) is list else v))
+            items.append((new_key, json.dumps(v, ensure_ascii=False) if type(v) is list else v))
     return dict(items)
         
 def persist_messages(delimiter, quotechar, messages, destination_path):

--- a/target_csv.py
+++ b/target_csv.py
@@ -32,7 +32,7 @@ def flatten(d, parent_key='', sep='__'):
         if isinstance(v, collections.MutableMapping):
             items.extend(flatten(v, new_key, sep=sep).items())
         else:
-            items.append((new_key, str(v) if type(v) is list else v))
+            items.append((new_key, json.dumps(v) if type(v) is list else v))
     return dict(items)
         
 def persist_messages(delimiter, quotechar, messages, destination_path):

--- a/target_csv_test.py
+++ b/target_csv_test.py
@@ -1,0 +1,26 @@
+import target_csv
+
+
+def test_flatten_empty():
+    res = target_csv.flatten({})
+    assert res == {}
+
+
+def test_flatten_simple():
+    res = target_csv.flatten({"f1": 1})
+    assert res == {"f1": 1}
+
+
+def test_flatten_list_simple():
+    res = target_csv.flatten({"f1": ["1", "2", 3]})
+    assert res == {"f1": '["1", "2", 3]'}
+
+
+def test_flatten_list_complex():
+    res = target_csv.flatten({"f1": [{"n": 1}, {"n": 2}]})
+    assert res == {"f1": '[{"n": 1}, {"n": 2}]'}
+
+
+def test_flatten_list_complex_non_ascii():
+    res = target_csv.flatten({"f1": [{"japanese": "私の問題を", "russian": "Удовлетворены"}]})
+    assert res == {"f1": '[{"japanese": "私の問題を", "russian": "Удовлетворены"}]'}

--- a/target_csv_test.py
+++ b/target_csv_test.py
@@ -1,4 +1,5 @@
 import target_csv
+import json
 
 
 def test_flatten_empty():
@@ -7,24 +8,34 @@ def test_flatten_empty():
 
 
 def test_flatten_simple():
-    x = target_csv.flatten({"f1": 1})
-    assert x == {"f1": 1}
+    x = target_csv.flatten({"f1": 1, "f2": "string", "f3": None, "f4": False})
+    assert x == {"f1": 1, "f2": "string", "f3": None, "f4": False}
 
 
 def test_flatten_list_simple():
-    x = target_csv.flatten({"f1": ["1", "2", 3]})
-    assert x == {"f1": '["1", "2", 3]'}
+    x = target_csv.flatten({"wrap": ["string", 1, None, False]})
+    # Previous implementation produced invalid json:
+    #   {"warp": "['string', 1, None, False]"}
+
+    json.loads(x['wrap'])
+    assert x == {"wrap": '["string", 1, null, false]'}
 
 
 def test_flatten_list_complex():
-    x = target_csv.flatten({"f1": [{"n": 1}, {"n": 2}]})
-    assert x == {"f1": '[{"n": 1}, {"n": 2}]'}
+    x = target_csv.flatten({"wrap": [{"n": 1}, {"n": 2}]})
+
+    json.loads(x['wrap'])
+    assert x == {"wrap": '[{"n": 1}, {"n": 2}]'}
 
 
 def test_flatten_list_complex_non_ascii():
-    x = target_csv.flatten(
-        {"f1": [
-            {"japanese": "私の問題を",
-             "russian": "Удовлетворены"}]
-        })
-    assert x == {"f1": '[{"japanese": "私の問題を", "russian": "Удовлетворены"}]'}
+    x = target_csv.flatten({
+        "wrap": [
+            {
+                "japanese": "私の問題を",
+                "russian": "Удовлетворены"
+            }
+        ]})
+
+    json.loads(x['wrap'])
+    assert x == {"wrap": '[{"japanese": "私の問題を", "russian": "Удовлетворены"}]'}

--- a/target_csv_test.py
+++ b/target_csv_test.py
@@ -22,5 +22,9 @@ def test_flatten_list_complex():
 
 
 def test_flatten_list_complex_non_ascii():
-    res = target_csv.flatten({"f1": [{"japanese": "私の問題を", "russian": "Удовлетворены"}]})
+    res = target_csv.flatten(
+        {"f1": [
+            {"japanese": "私の問題を",
+             "russian": "Удовлетворены"}]
+        })
     assert res == {"f1": '[{"japanese": "私の問題を", "russian": "Удовлетворены"}]'}

--- a/target_csv_test.py
+++ b/target_csv_test.py
@@ -2,29 +2,29 @@ import target_csv
 
 
 def test_flatten_empty():
-    res = target_csv.flatten({})
-    assert res == {}
+    x = target_csv.flatten({})
+    assert x == {}
 
 
 def test_flatten_simple():
-    res = target_csv.flatten({"f1": 1})
-    assert res == {"f1": 1}
+    x = target_csv.flatten({"f1": 1})
+    assert x == {"f1": 1}
 
 
 def test_flatten_list_simple():
-    res = target_csv.flatten({"f1": ["1", "2", 3]})
-    assert res == {"f1": '["1", "2", 3]'}
+    x = target_csv.flatten({"f1": ["1", "2", 3]})
+    assert x == {"f1": '["1", "2", 3]'}
 
 
 def test_flatten_list_complex():
-    res = target_csv.flatten({"f1": [{"n": 1}, {"n": 2}]})
-    assert res == {"f1": '[{"n": 1}, {"n": 2}]'}
+    x = target_csv.flatten({"f1": [{"n": 1}, {"n": 2}]})
+    assert x == {"f1": '[{"n": 1}, {"n": 2}]'}
 
 
 def test_flatten_list_complex_non_ascii():
-    res = target_csv.flatten(
+    x = target_csv.flatten(
         {"f1": [
             {"japanese": "私の問題を",
              "russian": "Удовлетворены"}]
         })
-    assert res == {"f1": '[{"japanese": "私の問題を", "russian": "Удовлетворены"}]'}
+    assert x == {"f1": '[{"japanese": "私の問題を", "russian": "Удовлетворены"}]'}


### PR DESCRIPTION
# Description of change
While flattening the list values are dumped as strings.
If the input fields contains a list of json, the result is invalid json. the representation of python dict object. For example `None` instead of `null` and `True` instead of `true`.

This PR uses replaces the string-dump with json.dumps(), not transforming to ascii chars, leaving the data intact.

# Manual QA steps
 - 
 
# Risks
 - 
 
# Rollback steps
 - revert this branch
