### PR TITLE
Respect the schema passed in the stream.

### DIFF
--- a/target_csv_test.py
+++ b/target_csv_test.py
@@ -1,0 +1,37 @@
+import target_csv
+import unittest
+
+
+class TestTargetCsv(unittest.TestCase):
+
+  def setUp(self):
+    pass
+
+  def test_get_headers(self):
+    schema = {"properties": {
+      'a': {'type': 'string'},
+      'b': {'type': 'array', 'items': {'type': 'string'}},
+      'c': {'type': 'object', 'properties': {'d': {'type': 'string'}}}
+    }}
+
+    assert target_csv.get_headers(schema) == ['a', 'b', 'c__d']
+
+  def test_get_headers_matches_flatten(self):
+    schema = {'properties': {
+      'a': {'type': 'string'},
+      'b': {'type': 'array', 'items': {'type': 'string'}},
+      'c': {'type': 'object', 'properties': {'d': {'type': 'string'}}}
+    }}
+
+    record = {
+      'a': 'alpha',
+      'b': ['beta'],
+      'c': {'d': 'delta'}
+    }
+
+    keys_from_schema = target_csv.get_headers(schema)
+    keys_from_records = list(target_csv.flatten(record).keys())
+    assert keys_from_schema == keys_from_records
+
+if __name__ == '__main__':
+  unittest.main()


### PR DESCRIPTION
* Extract headers from schema object and use those headers to write to the CSV.

* Write tests that flatten and get_headers produce the same keys.

# Description of change
Currently this integration does not use schema to set headers in the CSV files. It instead relies on what is already in the file or the keys it can find in the record. I believe this is the source of these issues https://github.com/singer-io/target-csv/issues/3 and https://github.com/singer-io/target-csv/issues/22. My understanding of the singer spec is that it would be appropriate to use the schema records to make sure the correct headers are used in the CSV files, instead of sampling records.

# Manual QA steps
 * Ran against the exchangeratesapi tap to sanity check that everything still worked. Wrote tests to check the specific behavior around missing headers. Happy to do more if this PR gains traction.
 
# Risks
* This change should be save, because if the record does not comply with the schema, the integration throws an error already. It will change the output in the cases where sampling the record was leading to incomplete headers, so it is technically a breaking change, but I think it is only breaking in cases that were already pretty broken.
 
# Rollback steps
* revert this branch
